### PR TITLE
Android version + returns promise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build
+*.iml

--- a/Readme.md
+++ b/Readme.md
@@ -2,12 +2,9 @@
 
 A react-native wrapper for reading existing localstorage created by apps built with cordova/phonegap.  This is useful if you built an app in cordova/phonegap (a webkit app) and now want access the localstorage from previous versions of the app in react native.
 
-### Note: 
-This module curretly only supports values stored as strings or JSON objects.  Pull requests are welcome if you would like this module to support other value types such as string.
-
 ## How it works
 
-This module reads the localstorage file stored in the `Library/WebKit/LocalStorage/file__0.localstorage` folder.  It cycles through all the entries and compiles the keys and values into a json object.  The json object is then converted into a string and returned by the ```get()``` method.  Below is the format of the json object that is returned as a string.
+This module reads the localstorage file stored in `Library/WebKit/LocalStorage/file__0.localstorage` for iOS and `app_webview/Local Storage/file__0.localstorage` for Android.  It cycles through all the entries and compiles the keys and values into a json object. 
 
 ```javascript
 {
@@ -21,7 +18,7 @@ This module reads the localstorage file stored in the `Library/WebKit/LocalStora
 
 ## Installation
 
-### Add it to your project
+### iOS
 
 1. Run `npm install react-native-webkit-localstorage-reader --save`.
 
@@ -32,22 +29,49 @@ This module reads the localstorage file stored in the `Library/WebKit/LocalStora
 4. Whenever you want to use it within React code now you just have to do: `var WebkitLocalStorageReader = require('NativeModules').WebkitLocalStorageReader;`
 
 
+### Android
+
+- Add the following lines to `android/settings.gradle`:
+
+```
+include ':react-native-webkit-localstorage-reader'
+project(':react-native-webkit-localstorage-reader').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-webkit-localstorage-reader/android')
+```
+
+- Update your `dependencies` in `android/app/build.gradle` with:
+
+```
+dependencies {
+  ...
+  compile project(':react-native-webkit-localstorage-reader')
+}
+ ```
+  
+- Be sure to have new WebkitLocalStorageReaderPackage() in your MainApplication.java 
+
+```
+import io.github.wootwoot1234.WebkitLocalStorageReaderPackage;
+...
+@Override
+     protected List<ReactPackage> getPackages() {
+         return Arrays.<ReactPackage>asList(
+                 new MainReactPackage(),
+                 new WebkitLocalStorageReaderPackage()
+         );
+     }
+```
+
+
 ## API
 
 ### Read Localstorage
 
-You have to load the products first to get the correctly internationalized name and price in the correct currency.
-
 ```javascript
-import {WebkitLocalStorageReader} from 'NativeModules';
-WebkitLocalStorageReader.get((jsonString) => {
-    if(jsonString) {
-        var jsonObj = JSON.parse(jsonString);
-        console.log(jsonObj);
-    } else {
-        console.log("No localstorage database file found.");
-    }
-});
+// you have session => { SESSION } in your localstorage
+import { WebkitLocalStorageReader } from 'NativeModules';
+
+const localStorage = await WebkitLocalStorageReader.get();
+const session = JSON.parse(localStorage.session);
 ```
 
 ## Testing

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,0 +1,21 @@
+apply plugin: 'com.android.library'
+
+android {
+    compileSdkVersion 23
+    buildToolsVersion "23.0.1"
+
+    defaultConfig {
+        minSdkVersion 16
+        targetSdkVersion 22
+        versionCode 1
+        versionName "1.0"
+        ndk {
+            abiFilters "armeabi-v7a", "x86"
+        }
+    }
+}
+
+dependencies {
+    compile fileTree(include: ['*.jar'], dir: 'libs')
+    compile "com.facebook.react:react-native:+"
+}

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="io.github.wootwoot1234">
+
+</manifest>

--- a/android/src/main/java/io/github/wootwoot1234/WebkitLocalStorageReaderModule.java
+++ b/android/src/main/java/io/github/wootwoot1234/WebkitLocalStorageReaderModule.java
@@ -1,0 +1,70 @@
+package io.github.wootwoot1234;
+
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.WritableNativeMap;
+
+import java.io.File;
+import java.nio.charset.Charset;
+
+
+public class WebkitLocalStorageReaderModule extends ReactContextBaseJavaModule {
+
+    public WebkitLocalStorageReaderModule(ReactApplicationContext reactContext) {
+        super(reactContext);
+    }
+
+    @Override
+    public String getName() {
+        return "WebkitLocalStorageReader";
+    }
+
+    @ReactMethod
+    public void get(Promise promise) {
+        WritableMap kv = new WritableNativeMap();
+        String dataDir = getReactApplicationContext().getApplicationInfo().dataDir;
+        File localstorage = new File(dataDir + "/app_webview/Local Storage/file__0.localstorage");
+
+        if (!localstorage.exists()) {
+            promise.resolve(kv);
+            return;
+        }
+
+        Cursor cursor = null;
+        SQLiteDatabase db = null;
+        try {
+            File dbfile = getReactApplicationContext().getDatabasePath(localstorage.getPath());
+            dbfile.setWritable(true);
+            db = SQLiteDatabase.openDatabase(dbfile.getAbsolutePath(), null, SQLiteDatabase.OPEN_READWRITE);
+
+            String sql = "SELECT key,value FROM ItemTable";
+            cursor = db.rawQuery(sql, null);
+            cursor.moveToFirst();
+            while (!cursor.isAfterLast()) {
+                String key = cursor.getString(0);
+                byte[] itemByteArray = cursor.getBlob(1);
+                String value = new String(itemByteArray, Charset.forName("UTF-16LE"));
+
+                kv.putString(key, value);
+                cursor.moveToNext();
+            }
+            promise.resolve(kv);
+        } catch (Exception e) {
+            e.printStackTrace();
+            promise.resolve(kv);
+        } finally {
+            if (cursor != null) {
+                cursor.close();
+            }
+            if (db != null) {
+                db.close();
+            }
+        }
+    }
+}

--- a/android/src/main/java/io/github/wootwoot1234/WebkitLocalStorageReaderPackage.java
+++ b/android/src/main/java/io/github/wootwoot1234/WebkitLocalStorageReaderPackage.java
@@ -1,0 +1,32 @@
+package io.github.wootwoot1234;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+import com.facebook.react.bridge.JavaScriptModule;
+
+public class WebkitLocalStorageReaderPackage implements ReactPackage {
+
+  @Override
+  public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
+    return Arrays.<NativeModule>asList(
+        new WebkitLocalStorageReaderModule(reactContext)
+    );
+  }
+
+  @Override
+    public List<Class<? extends JavaScriptModule>> createJSModules() {
+      return Collections.emptyList();
+    }
+
+    @Override
+    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+      return Collections.emptyList();
+    }
+
+}


### PR DESCRIPTION
- Add Android version with same API:  `WebkitLocalStorageReader.get();`
- [iOS / Android] returns a promise with content of localstorage
- Breaking change: the returned value is not a string, but an object. This is the same object you would get when using localStorage from a web browser. 